### PR TITLE
Add Dask Gateway example

### DIFF
--- a/03_example-dask.ipynb
+++ b/03_example-dask.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask_gateway import Gateway\n",
+    "from dask.distributed import Client\n",
+    "\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = Client(cluster)\n",
+    "client"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/binder-gallery.yaml
+++ b/binder-gallery.yaml
@@ -1,3 +1,4 @@
+---
 name: Example Gallery
 description: >-
   An example gallery of notebooks used for debugging the Pangeo Gallery

--- a/binder-gallery.yaml
+++ b/binder-gallery.yaml
@@ -3,7 +3,7 @@ description: >-
   An example gallery of notebooks used for debugging the Pangeo Gallery
   infrastructure.
 gallery_repository: pangeo-gallery/pangeo-gallery
-binder_url: "http://mybinder.org"
-binder_repo: choldgraf/binder-sandbox
+binder_url: "https://binder.pangeo.io"
+binder_repo: pangeo-gallery/default-binderngeo-gallery/default-binder
 binder_ref: master
 binderbot_target_branch: binderbot-built

--- a/binder-gallery.yaml
+++ b/binder-gallery.yaml
@@ -4,6 +4,6 @@ description: >-
   infrastructure.
 gallery_repository: pangeo-gallery/pangeo-gallery
 binder_url: "https://binder.pangeo.io"
-binder_repo: pangeo-gallery/default-binderngeo-gallery/default-binder
+binder_repo: pangeo-gallery/default-binder
 binder_ref: master
 binderbot_target_branch: binderbot-built


### PR DESCRIPTION
@rabernat a test / example using dask. Some questions

1. I see the other notebooks have their output included. Is that necessary? Creating the `Gateway` won't generally work outside of a machine that's been configured (like `hub.pangeo.io`)
2. (where) are these run as part of CI / CD? Wherever that is will need to have dask-gateway installed & configured.

If this is likely to cause issues we might want to hold off on merging.